### PR TITLE
fix(deps): update go-version to v1.22.7 fix #33

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,4 +9,4 @@ jobs:
   goreleaser:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser.yml@main
     with:
-      go-version: "1.22.5"
+      go-version: "1.22.7"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,4 +15,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.22.5"
+      go-version: "1.22.7"


### PR DESCRIPTION
HIGH: https://scout.docker.com/v/CVE-2022-30635?s=golang&n=stdlib&t=golang&vr=%3C1.22.7