### PR TITLE
Add --stdin-on-term-announce and --stdin-on-term-delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,14 @@ the sub-command with the current uid and gid.
 - `--stdin-on-term MESSAGE` : some applications prefer to be gracefully stopped with a command on
    stdin rather than handling SIGTERM, such as Minecraft servers. 
    The `MESSAGE` and a newline will be written to the sub-command's stdin when a `TERM` signal is received.
-- `--stdin-on-term-announce MESSAGE` : if set along with `--stdin-on-term`, this `MESSAGE` (plus a newline)
-   is written to the sub-command's stdin first when a `TERM` signal is received, then
-   `--stdin-on-term-announce-delay` is awaited before the `--stdin-on-term` message is sent. This gives
-   users a heads-up before the application is stopped. Any `%delay%` token in the message is replaced with
-   the whole-second value of the delay (e.g. for a Minecraft server, `say Server stopping in %delay% seconds`).
-   A second `TERM` signal received during the wait skips the remaining delay.
-- `--stdin-on-term-announce-delay DURATION` : how long to wait between the announce message and the
-   `--stdin-on-term` message, as a [Go duration](https://pkg.go.dev/time#ParseDuration) (e.g. `30s`). Keep
-   this shorter than the container's stop grace period (e.g. `docker stop -t`) so the `--stdin-on-term`
-   message is sent before the container is force-killed.
+- `--stdin-on-term-announce MESSAGE` : optional message written to the sub-command's stdin when `TERM`
+   is received, *before* `--stdin-on-term-delay` and the `--stdin-on-term` message — e.g. a heads-up to
+   connected users. A `%delay%` token is replaced with the whole-second value of `--stdin-on-term-delay`
+   (e.g. `say Server stopping in %delay% seconds`).
+- `--stdin-on-term-delay DURATION` : optional wait ([Go duration](https://pkg.go.dev/time#ParseDuration),
+   e.g. `30s`) after `TERM`, before the `--stdin-on-term` message is written — independent of
+   `--stdin-on-term-announce`. A second `TERM` skips the remaining wait. Keep it shorter than the
+   container's stop grace (`docker stop -t`), or the stop message won't be sent before force-kill.
 - `--debug` : enables debug logging
 - `--version` : show version and exit
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ the sub-command with the current uid and gid.
 - `--stdin-on-term MESSAGE` : some applications prefer to be gracefully stopped with a command on
    stdin rather than handling SIGTERM, such as Minecraft servers. 
    The `MESSAGE` and a newline will be written to the sub-command's stdin when a `TERM` signal is received.
+- `--stdin-on-term-announce MESSAGE` : if set along with `--stdin-on-term`, this `MESSAGE` (plus a newline)
+   is written to the sub-command's stdin first when a `TERM` signal is received, then
+   `--stdin-on-term-announce-delay` is awaited before the `--stdin-on-term` message is sent. This gives
+   users a heads-up before the application is stopped. Any `%delay%` token in the message is replaced with
+   the whole-second value of the delay (e.g. for a Minecraft server, `say Server stopping in %delay% seconds`).
+   A second `TERM` signal received during the wait skips the remaining delay.
+- `--stdin-on-term-announce-delay DURATION` : how long to wait between the announce message and the
+   `--stdin-on-term` message, as a [Go duration](https://pkg.go.dev/time#ParseDuration) (e.g. `30s`). Keep
+   this shorter than the container's stop grace period (e.g. `docker stop -t`) so the `--stdin-on-term`
+   message is sent before the container is force-killed.
 - `--debug` : enables debug logging
 - `--version` : show version and exit
 

--- a/cmd/entrypoint-demoter/main.go
+++ b/cmd/entrypoint-demoter/main.go
@@ -24,9 +24,9 @@ var config struct {
 	Version     bool   `usage:"Show version info and exit"`
 	StdinOnTerm string `usage:"If set, the given content will be written to the sub-command's stdin when TERM signal is received"`
 
-	StdinOnTermAnnounce string `usage:"If set along with stdin-on-term, this content is written to the sub-command's stdin first when TERM is received, then stdin-on-term-announce-delay is awaited before the stdin-on-term content is written. A %delay% token is replaced with the whole-second value of the delay."`
+	StdinOnTermAnnounce string `usage:"If set, written to the sub-command's stdin when TERM is received, before any stdin-on-term-delay and the stdin-on-term content. A %delay% token is replaced with the whole-second value of stdin-on-term-delay."`
 
-	StdinOnTermAnnounceDelay time.Duration `usage:"How long to wait after writing the stdin-on-term-announce content before writing the stdin-on-term content. Keep shorter than the container's stop grace period."`
+	StdinOnTermDelay time.Duration `usage:"If set, waited after TERM (and after writing any stdin-on-term-announce) before the stdin-on-term content is written. Keep shorter than the container's stop grace period."`
 }
 
 func main() {
@@ -56,7 +56,7 @@ func main() {
 		log.WithError(err).Fatal("Failed to resolve IDs")
 	}
 
-	err = entrypoint_demoter.RunCommand(uid, gid, config.StdinOnTerm, config.StdinOnTermAnnounce, config.StdinOnTermAnnounceDelay, args)
+	err = entrypoint_demoter.RunCommand(uid, gid, config.StdinOnTerm, config.StdinOnTermAnnounce, config.StdinOnTermDelay, args)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitErr.ExitCode())

--- a/cmd/entrypoint-demoter/main.go
+++ b/cmd/entrypoint-demoter/main.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
+	"time"
 )
 
 var (
@@ -22,6 +23,10 @@ var config struct {
 	Debug       bool   `usage:"Enable debug logging"`
 	Version     bool   `usage:"Show version info and exit"`
 	StdinOnTerm string `usage:"If set, the given content will be written to the sub-command's stdin when TERM signal is received"`
+
+	StdinOnTermAnnounce string `usage:"If set along with stdin-on-term, this content is written to the sub-command's stdin first when TERM is received, then stdin-on-term-announce-delay is awaited before the stdin-on-term content is written. A %delay% token is replaced with the whole-second value of the delay."`
+
+	StdinOnTermAnnounceDelay time.Duration `usage:"How long to wait after writing the stdin-on-term-announce content before writing the stdin-on-term content. Keep shorter than the container's stop grace period."`
 }
 
 func main() {
@@ -51,7 +56,7 @@ func main() {
 		log.WithError(err).Fatal("Failed to resolve IDs")
 	}
 
-	err = entrypoint_demoter.RunCommand(uid, gid, config.StdinOnTerm, args)
+	err = entrypoint_demoter.RunCommand(uid, gid, config.StdinOnTerm, config.StdinOnTermAnnounce, config.StdinOnTermAnnounceDelay, args)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitErr.ExitCode())

--- a/run.go
+++ b/run.go
@@ -14,11 +14,11 @@ import (
 	"time"
 )
 
-func RunCommand(uid uint32, gid uint32, stdinOnTerm, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string) error {
+func RunCommand(uid uint32, gid uint32, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string) error {
 	return RunCommandWithListeners(uid, gid, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermAnnounceDelay, commandAndArgs)
 }
 
-func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string, listeners ...StdInOutListener) error {
+func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string, listeners ...StdInOutListener) error {
 	command := exec.Command(commandAndArgs[0], commandAndArgs[1:]...)
 	command.Stderr = os.Stderr
 
@@ -63,7 +63,7 @@ func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm, stdinOnTermAnn
 	return nil
 }
 
-func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, stdinPipe io.Writer) {
+func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, stdinPipe io.Writer) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGTERM)
 
@@ -76,7 +76,7 @@ func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm, stdi
 				if stdinOnTerm != "" && sig == syscall.SIGTERM {
 					if stdinOnTermAnnounce != "" {
 						announce := strings.ReplaceAll(stdinOnTermAnnounce, "%delay%",
-							strconv.Itoa(int(stdinOnTermAnnounceDelay.Seconds())))
+							strconv.FormatInt(int64(stdinOnTermAnnounceDelay/time.Second), 10))
 						log.WithField("message", announce).Debug("Sending announce on stdin due to SIGTERM")
 						stdinPipe.Write([]byte(announce + "\n"))
 
@@ -84,11 +84,14 @@ func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm, stdi
 							// Wait before sending the stop message, but let a second TERM
 							// (e.g. an impatient `docker stop`) short-circuit the wait so we
 							// never block past the container's stop grace period.
+							timer := time.NewTimer(stdinOnTermAnnounceDelay)
 							select {
-							case <-time.After(stdinOnTermAnnounceDelay):
+							case <-timer.C:
 							case <-signals:
+								timer.Stop()
 								log.Debug("Second TERM received; skipping remaining announce delay")
 							case <-ctx.Done():
+								timer.Stop()
 								return
 							}
 						}

--- a/run.go
+++ b/run.go
@@ -8,14 +8,17 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
 )
 
-func RunCommand(uid uint32, gid uint32, stdinOnTerm string, commandAndArgs []string) error {
-	return RunCommandWithListeners(uid, gid, stdinOnTerm, commandAndArgs)
+func RunCommand(uid uint32, gid uint32, stdinOnTerm, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string) error {
+	return RunCommandWithListeners(uid, gid, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermAnnounceDelay, commandAndArgs)
 }
 
-func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, commandAndArgs []string, listeners ...StdInOutListener) error {
+func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string, listeners ...StdInOutListener) error {
 	command := exec.Command(commandAndArgs[0], commandAndArgs[1:]...)
 	command.Stderr = os.Stderr
 
@@ -50,7 +53,7 @@ func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, command
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	setupSignalForwarding(ctx, command, stdinOnTerm, stdinPipe)
+	setupSignalForwarding(ctx, command, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermAnnounceDelay, stdinPipe)
 
 	err = command.Wait()
 	if err != nil {
@@ -60,7 +63,7 @@ func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, command
 	return nil
 }
 
-func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm string, stdinPipe io.Writer) {
+func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, stdinPipe io.Writer) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGTERM)
 
@@ -71,6 +74,26 @@ func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm strin
 				log.WithField("signal", sig).Debug("Forwarding signal")
 
 				if stdinOnTerm != "" && sig == syscall.SIGTERM {
+					if stdinOnTermAnnounce != "" {
+						announce := strings.ReplaceAll(stdinOnTermAnnounce, "%delay%",
+							strconv.Itoa(int(stdinOnTermAnnounceDelay.Seconds())))
+						log.WithField("message", announce).Debug("Sending announce on stdin due to SIGTERM")
+						stdinPipe.Write([]byte(announce + "\n"))
+
+						if stdinOnTermAnnounceDelay > 0 {
+							// Wait before sending the stop message, but let a second TERM
+							// (e.g. an impatient `docker stop`) short-circuit the wait so we
+							// never block past the container's stop grace period.
+							select {
+							case <-time.After(stdinOnTermAnnounceDelay):
+							case <-signals:
+								log.Debug("Second TERM received; skipping remaining announce delay")
+							case <-ctx.Done():
+								return
+							}
+						}
+					}
+
 					log.WithField("message", stdinOnTerm).Debug("Sending message on stdin due to SIGTERM")
 					stdinPipe.Write([]byte(stdinOnTerm + "\n"))
 					continue

--- a/run.go
+++ b/run.go
@@ -14,11 +14,11 @@ import (
 	"time"
 )
 
-func RunCommand(uid uint32, gid uint32, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string) error {
-	return RunCommandWithListeners(uid, gid, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermAnnounceDelay, commandAndArgs)
+func RunCommand(uid uint32, gid uint32, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermDelay time.Duration, commandAndArgs []string) error {
+	return RunCommandWithListeners(uid, gid, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermDelay, commandAndArgs)
 }
 
-func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, commandAndArgs []string, listeners ...StdInOutListener) error {
+func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermDelay time.Duration, commandAndArgs []string, listeners ...StdInOutListener) error {
 	command := exec.Command(commandAndArgs[0], commandAndArgs[1:]...)
 	command.Stderr = os.Stderr
 
@@ -53,7 +53,7 @@ func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, stdinOn
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	setupSignalForwarding(ctx, command, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermAnnounceDelay, stdinPipe)
+	setupSignalForwarding(ctx, command, stdinOnTerm, stdinOnTermAnnounce, stdinOnTermDelay, stdinPipe)
 
 	err = command.Wait()
 	if err != nil {
@@ -63,7 +63,7 @@ func RunCommandWithListeners(uid uint32, gid uint32, stdinOnTerm string, stdinOn
 	return nil
 }
 
-func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermAnnounceDelay time.Duration, stdinPipe io.Writer) {
+func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm string, stdinOnTermAnnounce string, stdinOnTermDelay time.Duration, stdinPipe io.Writer) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGTERM)
 
@@ -76,24 +76,24 @@ func setupSignalForwarding(ctx context.Context, cmd *exec.Cmd, stdinOnTerm strin
 				if stdinOnTerm != "" && sig == syscall.SIGTERM {
 					if stdinOnTermAnnounce != "" {
 						announce := strings.ReplaceAll(stdinOnTermAnnounce, "%delay%",
-							strconv.FormatInt(int64(stdinOnTermAnnounceDelay/time.Second), 10))
+							strconv.FormatInt(int64(stdinOnTermDelay/time.Second), 10))
 						log.WithField("message", announce).Debug("Sending announce on stdin due to SIGTERM")
 						stdinPipe.Write([]byte(announce + "\n"))
+					}
 
-						if stdinOnTermAnnounceDelay > 0 {
-							// Wait before sending the stop message, but let a second TERM
-							// (e.g. an impatient `docker stop`) short-circuit the wait so we
-							// never block past the container's stop grace period.
-							timer := time.NewTimer(stdinOnTermAnnounceDelay)
-							select {
-							case <-timer.C:
-							case <-signals:
-								timer.Stop()
-								log.Debug("Second TERM received; skipping remaining announce delay")
-							case <-ctx.Done():
-								timer.Stop()
-								return
-							}
+					if stdinOnTermDelay > 0 {
+						// Wait before sending the stop message, but let a second TERM
+						// (e.g. an impatient `docker stop`) short-circuit the wait so we
+						// never block past the container's stop grace period.
+						timer := time.NewTimer(stdinOnTermDelay)
+						select {
+						case <-timer.C:
+						case <-signals:
+							timer.Stop()
+							log.Debug("Second TERM received; skipping remaining delay")
+						case <-ctx.Done():
+							timer.Stop()
+							return
 						}
 					}
 

--- a/test.sh
+++ b/test.sh
@@ -34,4 +34,14 @@ assert "stdin-on-term" "hello" "$(docker logs ${id})"
 # shellcheck disable=SC2086
 docker rm ${id}
 
+# announce is written first, then (after the delay) the stdin-on-term message.
+# -t must exceed the announce delay, or the container is killed before the stop message is sent.
+id=$(docker run -d entrypoint-demoter-test --stdin-on-term "stop" --stdin-on-term-announce "warning" --stdin-on-term-announce-delay 1s cat -)
+# shellcheck disable=SC2086
+docker stop -t 5 ${id}
+# shellcheck disable=SC2086
+assert "stdin-on-term-announce" "$(printf 'warning\nstop')" "$(docker logs ${id})"
+# shellcheck disable=SC2086
+docker rm ${id}
+
 echo "ALL PASSED"

--- a/test.sh
+++ b/test.sh
@@ -34,13 +34,22 @@ assert "stdin-on-term" "hello" "$(docker logs ${id})"
 # shellcheck disable=SC2086
 docker rm ${id}
 
-# announce is written first, then (after the delay) the stdin-on-term message.
-# -t must exceed the announce delay, or the container is killed before the stop message is sent.
-id=$(docker run -d entrypoint-demoter-test --stdin-on-term "stop" --stdin-on-term-announce "warning" --stdin-on-term-announce-delay 1s cat -)
+# announce, then (after the delay) the stop message.
+# -t must exceed the delay, or the container is killed before the stop message is sent.
+id=$(docker run -d entrypoint-demoter-test --stdin-on-term "stop" --stdin-on-term-announce "warning" --stdin-on-term-delay 1s cat -)
 # shellcheck disable=SC2086
 docker stop -t 5 ${id}
 # shellcheck disable=SC2086
 assert "stdin-on-term-announce" "$(printf 'warning\nstop')" "$(docker logs ${id})"
+# shellcheck disable=SC2086
+docker rm ${id}
+
+# delay without announce: silent grace period, then just the stop message
+id=$(docker run -d entrypoint-demoter-test --stdin-on-term "stop" --stdin-on-term-delay 1s cat -)
+# shellcheck disable=SC2086
+docker stop -t 5 ${id}
+# shellcheck disable=SC2086
+assert "stdin-on-term-delay (no announce)" "stop" "$(docker logs ${id})"
 # shellcheck disable=SC2086
 docker rm ${id}
 


### PR DESCRIPTION
(follow on work for itzg/docker-minecraft-bedrock-server#642)

Extends `--stdin-on-term` with two optional, **independent** steps. On `TERM` (when `--stdin-on-term` is set):

1. write `--stdin-on-term-announce` to stdin, if set
2. wait `--stdin-on-term-delay`, if set
3. write the `--stdin-on-term` message

The first two each work on their own — an announce with no delay (immediate heads-up, then stop), or a delay with no announce (a silent grace period to let in-flight work drain).

- New flags: `--stdin-on-term-announce MESSAGE`, `--stdin-on-term-delay DURATION`
- A `%delay%` token in the announce `MESSAGE` is replaced with the whole-second value of `--stdin-on-term-delay` (e.g. `say Server stopping in %delay% seconds`)
- A second `TERM` during the wait short-circuits the remaining delay, so the stop message isn't blocked past the container's stop grace (`docker stop -t`)
- Backward compatible: with neither new flag set, behavior is unchanged
- README/usage docs + integration tests in `test.sh` (announce+delay, and delay-alone)

**:exclamation: Note:** the `run 1000` integration test is flaky on my Docker Desktop (a pre-existing stdout-fanout race on fast-exiting children, unrelated to this change).
